### PR TITLE
docs(license): add MIT license (0.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+### Added
+- MIT license

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Clara Sorrenti
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- add MIT license file
- document license in initial changelog

## Rationale and Context
Establishes explicit licensing for the project and records it in the changelog for traceability.

## SemVer Justification
Patch release: documentation-only change.

## Test Evidence
- `cargo test` *(fails: could not find `Cargo.toml`)*

## Risk Assessment and Rollback Plan
Low risk: removing `LICENSE` and `CHANGELOG.md` files would revert.

## Affected Packages
- N/A

## Checklist
- [x] Intake analysis complete
- [x] Plan reviewed and approved
- [ ] Version files updated
- [x] CHANGELOG.md updated
- [ ] CI pipeline passing
- [x] Documentation synchronized
- [ ] Security audit complete
- [ ] Release tags prepared


------
https://chatgpt.com/codex/tasks/task_e_68a1a1f58e50833291cbd2f2a6b984e1