### PR TITLE
docs(repo): add arch linux instructions and tooling (0.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+
+## [0.1.1] - 2025-08-17
+### Added
+- Arch Linux setup and usage instructions in README
+- `toaster.md` architecture overview
+- `codex.sh` helper script
+### Changed
+- Bump crate version to 0.1.1
+
+## [0.1.0] - 2025-08-17
 ### Added
 - MIT license
 - Initialize `repo-harvest` Rust crate

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # cinder-file-get
+
+`cinder-file-get` retrieves selected files from a GitHub repository to build a lightweight helper pack for LLM tooling.
+
+## Arch Linux setup
+
+```bash
+sudo pacman -S --needed base-devel git rustup
+rustup default stable
+```
+
+## Build and test
+
+```bash
+cd repo-harvest
+cargo test
+cargo build --release
+```
+
+## Example usage
+
+```bash
+repo-harvest init example \
+  --repo owner/repo \
+  --out ~/harvests \
+  --include 'src/**' --exclude 'target/**'
+```
+
+The `codex.sh` script offers dry-run helpers for bootstrap and validation. See [AGENTS.md](AGENTS.md) for detailed concepts and options.

--- a/codex.sh
+++ b/codex.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ${EUID:-$(id -u)} -eq 0 && "${ALLOW_ROOT:-0}" -ne 1 ]]; then
+	echo "Refusing to run as root; use ALLOW_ROOT=1 to override" >&2
+	exit 1
+fi
+
+DRY_RUN=1
+if [[ "${1:-}" == "--confirm" ]]; then
+	DRY_RUN=0
+	shift
+fi
+
+run() {
+	if [[ $DRY_RUN -eq 1 ]]; then
+		echo "[dry-run] $*"
+	else
+		"$@"
+	fi
+}
+
+cmd=${1:-help}
+shift || true
+
+case "$cmd" in
+bootstrap)
+	run cargo build --release
+	;;
+fast-validate)
+	run cargo test
+	;;
+cache-warm)
+	run cargo build
+	;;
+daemon:status)
+	run echo daemon status
+	;;
+daemon:start)
+	run echo starting daemon
+	;;
+daemon:stop)
+	run echo stopping daemon
+	;;
+codex:repair)
+	run cargo fix --allow-dirty
+	;;
+*)
+	echo "Usage: $0 [--confirm] {bootstrap|fast-validate|cache-warm|daemon:{status|start|stop}|codex:repair}"
+	;;
+esac

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,19 @@
+# Plan
+
+## Goals
+- Provide usable documentation and setup instructions, especially for Arch Linux.
+- Supply missing project scaffolding files: `toaster.md` for architecture overview and `codex.sh` utility script.
+- Update README with build and usage instructions.
+- Bump crate version to 0.1.1 and record changes in CHANGELOG.
+
+## Tests
+- `cargo test`
+- `shellcheck codex.sh`
+- `shfmt -w codex.sh`
+- `cargo audit` (dependency security check)
+
+## SemVer Impact
+- Patch release: 0.1.0 → 0.1.1 (documentation and tooling only).
+
+## Rollback Strategy
+- Revert commit: `git revert <commit>` if issues arise.

--- a/repo-harvest/Cargo.lock
+++ b/repo-harvest/Cargo.lock
@@ -947,7 +947,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "repo-harvest"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "camino",

--- a/repo-harvest/Cargo.toml
+++ b/repo-harvest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repo-harvest"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 

--- a/toaster.md
+++ b/toaster.md
@@ -1,0 +1,8 @@
+# Architecture Overview
+```mermaid
+flowchart TD
+    A[Entry Points] --> B[Core Logic] --> C[External Systems]
+    D[codex.sh] --> B
+```
+**Interfaces**: `repo-harvest` CLI, filesystem, GitHub API
+**Critical paths**: build (`cargo build`), testing (`cargo test`), release (`codex.sh bootstrap`)


### PR DESCRIPTION
## Summary
- document Arch Linux setup and basic usage in README
- add repository scaffolding files: `toaster.md` architecture overview and `codex.sh` helper script
- bump crate to v0.1.1 and record changes in CHANGELOG

## Rationale
Adds missing documentation and operational scripts so contributors can build and validate the project on Arch systems.

## SemVer
Patch release (0.1.0 -> 0.1.1): documentation and tooling only.

## Testing
- `cargo test`
- `cargo build --release`
- `cargo audit --no-fetch`
- `shfmt -w codex.sh`
- `shellcheck codex.sh`

## Risk
Low: doc and helper-script additions without functional code changes.

## Affected packages
- repo-harvest

## Checklist
- [ ] Analysis complete
- [ ] Docs synced
- [ ] CI green
- [ ] Security audit
- [ ] Tags prepared
- [ ] codex.sh validated


------
https://chatgpt.com/codex/tasks/task_e_68a1aa33eec08332a29ce1e531339c75