### PR TITLE
feat(cli): add interactive init subcommand (0.2.0)

### DIFF
--- a/.finishesignore
+++ b/.finishesignore
@@ -1,0 +1,3 @@
+# Patterns for finishes to ignore
+.git/
+target/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Initial `finishes` crate with logging and CLI skeleton
+- Interactive `finishes init` subcommand with config persistence
+  and `.finishesignore` template
 
 ### Changed
 - Bump `repo-harvest` crate version to 0.2.0
+- Bump `finishes` crate version to 0.2.0
 
 ## [0.1.1] - 2025-08-17
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ cargo build --release
 ## Example usage
 
 ```bash
-finishes init example \
-  --repo owner/repo \
-  --out ~/harvests \
-  --include 'src/**' --exclude 'target/**'
+finishes init
+# follow prompts for repo path, destination, and file types
 ```
+
+Configuration is saved to `~/.config/finishes/config.json` and a `.finishesignore`
+template is written to the chosen repository if absent.
 
 The `codex.sh` script offers dry-run helpers for bootstrap and validation. See [AGENTS.md](AGENTS.md) for detailed concepts and options.
 

--- a/finishes/Cargo.lock
+++ b/finishes/Cargo.lock
@@ -230,6 +230,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,9 +258,10 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "finishes"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
+ "dirs",
  "ignore",
  "inquire",
  "serde",
@@ -258,6 +280,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -336,6 +369,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "libredox"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+dependencies = [
+ "bitflags 2.9.2",
+ "libc",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +453,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +518,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]

--- a/finishes/Cargo.toml
+++ b/finishes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finishes"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]
@@ -13,3 +13,4 @@ serde_json = "1"
 sha2 = "0.10"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+dirs = "5"

--- a/finishes/src/cli.rs
+++ b/finishes/src/cli.rs
@@ -1,10 +1,55 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
+use inquire::{MultiSelect, Text};
+use std::{fs, path::Path};
+
+use crate::config::Config;
 
 #[derive(Debug, Parser)]
 #[command(author, version, about)]
-pub struct Cli {}
+pub struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    /// Initialize finishes configuration
+    Init,
+}
 
 pub fn run() -> Result<(), Box<dyn std::error::Error>> {
-    let _ = Cli::parse();
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Init => init()?,
+    }
+
+    Ok(())
+}
+
+fn init() -> Result<(), Box<dyn std::error::Error>> {
+    let repo = Text::new("Source repository path:").prompt()?;
+    let dest = Text::new("Destination directory:").prompt()?;
+    let options = vec!["rs", "md", "toml"];
+    let file_types = MultiSelect::new("Select file types", options).prompt()?;
+
+    let config = Config {
+        source_repo: repo.into(),
+        destination: dest.into(),
+        file_types: file_types.into_iter().map(|s| s.to_string()).collect(),
+    };
+
+    let config_dir = dirs::config_dir()
+        .ok_or("unable to determine config directory")?
+        .join("finishes");
+    fs::create_dir_all(&config_dir)?;
+    let config_path = config_dir.join("config.json");
+    fs::write(&config_path, serde_json::to_string_pretty(&config)?)?;
+
+    let ignore_path = Path::new(&config.source_repo).join(".finishesignore");
+    if !ignore_path.exists() {
+        fs::write(&ignore_path, "# Patterns to ignore\n")?;
+    }
+
     Ok(())
 }

--- a/finishes/src/config.rs
+++ b/finishes/src/config.rs
@@ -1,4 +1,9 @@
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct Config {}
+pub struct Config {
+    pub source_repo: PathBuf,
+    pub destination: PathBuf,
+    pub file_types: Vec<String>,
+}

--- a/plan.md
+++ b/plan.md
@@ -1,9 +1,9 @@
 # Plan
 
 ## Goals
-- Introduce new `finishes` crate with CLI skeleton and logging.
-- Expose foundational modules for configuration and file operations.
-- Record crate addition in `CHANGELOG.md`.
+- Add `finishes init` subcommand using `clap`.
+- Collect repo path, destination, and file types via `inquire` prompts.
+- Persist configuration JSON and create `.finishesignore` template.
 
 ## Tests
 - `cargo fmt --all --check`
@@ -12,7 +12,7 @@
 - `cargo build --release`
 
 ## SemVer Impact
-- Minor release: 0.1.1 → 0.2.0 (new functionality).
+- Minor release: 0.1.0 → 0.2.0 (new functionality).
 
 ## Rollback Strategy
-- `git revert <commit>` to remove the new crate.
+- `git revert <commit>` to remove the subcommand and related files.


### PR DESCRIPTION
## Summary
- add `finishes init` subcommand with interactive prompts
- save configuration to platform config directory and create `.finishesignore`
- bump `finishes` crate to 0.2.0

## Rationale
- provide guided setup for harvesting files and persist configuration for reuse

## SemVer Justification
- MINOR: backward-compatible CLI feature addition

## Testing
- `cargo fmt --all --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo build --release`

## Risk
- Low: new subcommand is isolated and defaults to local file operations

## Affected Packages
- finishes

## Checklist
- [x] Analysis complete
- [x] Docs synced
- [x] CI green
- [ ] Security audit
- [ ] Tags prepared
- [x] codex.sh validated

------
https://chatgpt.com/codex/tasks/task_e_68a1b36fa0b0833294e9c3e5faf5fc58