### PR TITLE
feat(finishes): add config and doctor commands (0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.0] - 2025-08-17
+### Added
+- `finishes config` subcommand to display or modify stored values
+- `finishes doctor` subcommand to validate paths and estimate export changes
+
+### Changed
+- Bump `finishes` crate version to 0.4.0
+
 ## [0.3.0] - 2025-08-17
 ### Added
 - Initial `finishes` crate with logging and CLI skeleton

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ finishes init
 
 finishes sync --dry-run
 # preview export without writing files
+
+finishes config --source /path/to/repo --dest /tmp/out --include rs --include md
+# update saved paths and include extensions
+
+finishes doctor
+# validate configuration and estimate copied files
 ```
 
 Configuration is saved to `~/.config/finishes/config.json` and a `.finishesignore`

--- a/finishes/Cargo.lock
+++ b/finishes/Cargo.lock
@@ -258,7 +258,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "finishes"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "dirs",

--- a/finishes/Cargo.toml
+++ b/finishes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finishes"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/finishes/src/cli.rs
+++ b/finishes/src/cli.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Parser, Subcommand};
 use inquire::{MultiSelect, Text};
-use std::{fs, path::Path, process::Command};
+use sha2::{Digest, Sha256};
+use std::{collections::HashMap, fs, io, path::{Path, PathBuf}, process::Command};
 
 use crate::{config::Config, copy, ignore, manifest, scan};
 
@@ -17,6 +18,10 @@ enum Commands {
     Init,
     /// Sync files based on saved configuration
     Sync(SyncArgs),
+    /// Display or update saved configuration
+    Config(ConfigArgs),
+    /// Diagnose configuration and export state
+    Doctor,
 }
 
 pub fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -25,6 +30,8 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
         Commands::Init => init()?,
         Commands::Sync(args) => sync(args)?,
+        Commands::Config(args) => config_cmd(args)?,
+        Commands::Doctor => doctor()?,
     }
 
     Ok(())
@@ -38,6 +45,16 @@ struct SyncArgs {
     clean: bool,
     #[arg(long)]
     force: bool,
+}
+
+#[derive(Debug, Args)]
+struct ConfigArgs {
+    #[arg(long)]
+    source: Option<PathBuf>,
+    #[arg(long)]
+    dest: Option<PathBuf>,
+    #[arg(long, action = clap::ArgAction::Append)]
+    include: Vec<String>,
 }
 
 fn sync(args: SyncArgs) -> Result<(), Box<dyn std::error::Error>> {
@@ -81,6 +98,113 @@ fn sync(args: SyncArgs) -> Result<(), Box<dyn std::error::Error>> {
         manifest_files,
         args.dry_run,
     )?;
+    Ok(())
+}
+
+fn config_cmd(args: ConfigArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let config_dir = dirs::config_dir()
+        .ok_or("unable to determine config directory")?
+        .join("finishes");
+    let config_path = config_dir.join("config.json");
+    let mut config: Config = if config_path.exists() {
+        serde_json::from_str(&fs::read_to_string(&config_path)?)?
+    } else {
+        Config {
+            source_repo: PathBuf::new(),
+            destination: PathBuf::new(),
+            file_types: Vec::new(),
+        }
+    };
+
+    let mut changed = false;
+    if let Some(src) = args.source {
+        config.source_repo = src;
+        changed = true;
+    }
+    if let Some(dest) = args.dest {
+        config.destination = dest;
+        changed = true;
+    }
+    if !args.include.is_empty() {
+        config.file_types = args.include;
+        changed = true;
+    }
+    if changed {
+        fs::create_dir_all(&config_dir)?;
+        fs::write(&config_path, serde_json::to_string_pretty(&config)?)?;
+    }
+    println!("source: {}", config.source_repo.display());
+    println!("dest: {}", config.destination.display());
+    println!("includes: {}", config.file_types.join(", "));
+    Ok(())
+}
+
+fn doctor() -> Result<(), Box<dyn std::error::Error>> {
+    let config_dir = dirs::config_dir()
+        .ok_or("unable to determine config directory")?
+        .join("finishes");
+    let config_path = config_dir.join("config.json");
+    let config: Config = serde_json::from_str(&fs::read_to_string(&config_path)?)?;
+
+    println!("source: {}", config.source_repo.display());
+    if !config.source_repo.exists() {
+        println!("  [!] missing source path");
+    }
+    println!("dest: {}", config.destination.display());
+    if !config.destination.exists() {
+        println!("  [!] destination does not exist");
+    }
+
+    println!("ignore rules:");
+    for name in [".gitignore", ".finishesignore"] {
+        let path = config.source_repo.join(name);
+        if path.exists() {
+            for line in fs::read_to_string(&path)?.lines() {
+                let line = line.trim();
+                if line.is_empty() || line.starts_with('#') {
+                    continue;
+                }
+                println!("  {name}: {line}");
+            }
+        }
+    }
+
+    let gitignore = ignore::build(&config.source_repo)?;
+    let files = scan::scan(&config.source_repo, &gitignore)?;
+    println!("candidate files: {}", files.len());
+    let mut total_bytes = 0u64;
+    for f in &files {
+        total_bytes += fs::metadata(f)?.len();
+    }
+    println!("total bytes: {total_bytes}");
+
+    let existing = manifest::read_manifest(&config.destination)?;
+    let mut manifest_map: HashMap<String, String> = HashMap::new();
+    if let Some(m) = existing {
+        for file in m.files {
+            manifest_map.insert(file.path, file.sha256);
+        }
+    }
+    let mut new_files = 0;
+    let mut changed_files = 0;
+    for path in &files {
+        let rel = path.strip_prefix(&config.source_repo)?;
+        let mut file = fs::File::open(path)?;
+        let mut hasher = Sha256::new();
+        io::copy(&mut file, &mut hasher)?;
+        let sha = hex::encode(hasher.finalize());
+        let key = rel.to_string_lossy().into_owned();
+        match manifest_map.get(&key) {
+            Some(existing_sha) if existing_sha == &sha => {}
+            Some(_) => changed_files += 1,
+            None => new_files += 1,
+        }
+    }
+    if new_files > 0 || changed_files > 0 {
+        println!("would copy {new_files} new and {changed_files} updated files");
+    } else {
+        println!("no changes detected");
+    }
     Ok(())
 }
 

--- a/finishes/src/manifest.rs
+++ b/finishes/src/manifest.rs
@@ -1,14 +1,14 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ManifestFile {
     pub path: String,
     pub bytes: u64,
     pub sha256: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ExportManifest {
     pub commit_sha: String,
     pub file_count: usize,
@@ -37,4 +37,16 @@ pub fn write_manifest(
         std::fs::write(path, json)?;
     }
     Ok(())
+}
+
+pub fn read_manifest(
+    dest: &Path,
+) -> Result<Option<ExportManifest>, Box<dyn std::error::Error>> {
+    let path = dest.join("export.manifest.json");
+    if !path.exists() {
+        return Ok(None);
+    }
+    let data = std::fs::read_to_string(path)?;
+    let manifest = serde_json::from_str(&data)?;
+    Ok(Some(manifest))
 }

--- a/plan.md
+++ b/plan.md
@@ -1,10 +1,9 @@
 # Plan
 
 ## Goals
-- Add `finishes sync` subcommand supporting `--dry-run`, `--clean`, and `--force`.
-- Traverse source using `ignore` + `walkdir` with `.gitignore` and `.finishesignore` unioned.
-- Copy allowed files (`.md`, `.mdx`, `.markdown`, `.go`, `.rs`, `.py`) to destination, enforcing 25 MB limit and rejecting unsafe symlinks.
-- Produce `export.manifest.json` containing commit SHA and file hashes.
+- Add `finishes config` subcommand to display or modify stored configuration values (source, destination, includes).
+- Add `finishes doctor` subcommand to validate paths, report ignore rules, count candidate files, and estimate export changes.
+- Bump `finishes` crate version to 0.4.0 and document new commands.
 
 ## Tests
 - `cargo fmt --all --check`
@@ -13,7 +12,7 @@
 - `cargo build --release`
 
 ## SemVer Impact
-- Minor release: 0.2.0 → 0.3.0 (new functionality).
+- Minor release: 0.3.0 → 0.4.0 (new features).
 
 ## Rollback Strategy
-- `git revert <commit>` to remove the sync subcommand and related files.
+- `git revert <commit>` to remove new subcommands and version bump.


### PR DESCRIPTION
## Summary
- add `finishes config` to view or update stored source/dest/include settings
- add `finishes doctor` to validate paths, show ignore rules, and preview export changes
- bump `finishes` crate to 0.4.0

## Rationale
Provides configuration management and diagnostics to streamline subsequent sync operations.

## SemVer
Minor bump: new backwards-compatible features.

## Testing
- `cargo fmt --all --check` (finishes, repo-harvest)
- `cargo clippy -- -D warnings` (finishes, repo-harvest)
- `cargo test` (finishes, repo-harvest)
- `cargo build --release` (finishes, repo-harvest)

## Risk
Low: operations are limited to reading/writing configuration files and scanning file system state.

## Affected Packages
- finishes

## Checklist
- [x] Analysis complete
- [x] Docs synced
- [x] CI green
- [x] Security audit
- [x] Tags prepared
- [x] codex.sh validated


------
https://chatgpt.com/codex/tasks/task_e_68a1bae3cd2083329b691cd840272dc7