### PR TITLE
ci(workflows): add finishes cross-platform testing (0.5.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: CI
 
 on:
   push:
@@ -6,10 +6,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     defaults:
       run:
-        working-directory: repo-harvest
+        working-directory: finishes
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
@@ -20,4 +24,5 @@ jobs:
       - run: cargo fmt -- --check
       - run: cargo clippy -- -D warnings
       - run: cargo test --all --locked
-      - run: cargo build --release
+      - run: cargo install cargo-dist --locked
+      - run: cargo dist build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- CI workflow to build and test `finishes` on `ubuntu-latest` and `macos-latest` with `cargo clippy`, `cargo test`, and `cargo dist` packaging.
+
 ## [0.5.0] - 2025-08-17
 ### Added
 - `finishes sync` supports `--clean` to wipe the destination and `--force` to overwrite existing files.

--- a/plan.md
+++ b/plan.md
@@ -1,17 +1,17 @@
 # Plan
 
 ## Goals
-- Release `finishes` crate version `0.5.0` and move `Unreleased` notes to a dated section.
-- Document `finishes` commands, configuration handling, and manifest features in docs.
+- Add GitHub Actions workflow to build and test the `finishes` crate on `ubuntu-latest` and `macos-latest`.
+- Ensure CI runs `cargo clippy`, `cargo test`, and `cargo dist` packaging.
 
 ## Tests
 - `cargo fmt --all --check`
 - `cargo clippy --manifest-path finishes/Cargo.toml -- -D warnings`
 - `cargo test --manifest-path finishes/Cargo.toml`
-- `cargo build --manifest-path finishes/Cargo.toml --release`
+- `cargo dist build --manifest-path finishes/Cargo.toml`
 
 ## SemVer Impact
-- Minor release: `0.4.2` → `0.5.0` (new features and documentation).
+- Patch release: workflow update only.
 
 ## Rollback Strategy
-- `git revert <commit>` to undo release changes.
+- `git revert <commit>` to restore the previous workflow.


### PR DESCRIPTION
## Summary
- run `finishes` tests on ubuntu-latest and macos-latest in CI

## Rationale
- ensure `finishes` builds and tests successfully across platforms

## SemVer justification
- Patch: CI-only workflow changes

## Test evidence
- `cargo fmt --manifest-path finishes/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path finishes/Cargo.toml -- -D warnings`
- `cargo test --manifest-path finishes/Cargo.toml`
- `dist build` *(fails: `You specified --artifacts, disabling host mode, but specified no targets to build!`)*

## Risk assessment
- low: CI-only; does not affect runtime code

## Affected packages
- `finishes`

---

- [ ] Analysis complete
- [ ] Docs synced
- [ ] CI green
- [ ] Security audit
- [ ] Tags prepared
- [ ] codex.sh validated


------
https://chatgpt.com/codex/tasks/task_e_68a1cb5d50f483328fb38a5d245031a0