### PR TITLE
fix(repo): direct codex.sh commands to finishes crate (0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - CI workflow to build and test `finishes` on `ubuntu-latest` and `macos-latest` with `cargo clippy`, `cargo test`, and `cargo dist` packaging.
 
+### Fixed
+- `codex.sh` commands now target the `finishes` crate and honor dry-run mode by default.
+
 ## [0.5.0] - 2025-08-17
 ### Added
 - `finishes sync` supports `--clean` to wipe the destination and `--force` to overwrite existing files.

--- a/codex.sh
+++ b/codex.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [[ ${EUID:-$(id -u)} -eq 0 && "${ALLOW_ROOT:-0}" -ne 1 ]]; then
-	echo "Refusing to run as root; use ALLOW_ROOT=1 to override" >&2
+	printf 'Refusing to run as root; use ALLOW_ROOT=1 to override\n' >&2
 	exit 1
 fi
 
@@ -14,24 +14,24 @@ fi
 
 run() {
 	if [[ $DRY_RUN -eq 1 ]]; then
-		echo "[dry-run] $*"
+		printf '[dry-run] %s\n' "$*"
 	else
 		"$@"
 	fi
 }
 
-cmd=${1:-help}
+cmd="${1:-help}"
 shift || true
 
 case "$cmd" in
 bootstrap)
-	run cargo build --release
+	run cargo build --manifest-path finishes/Cargo.toml --release
 	;;
 fast-validate)
-	run cargo test
+	run cargo test --manifest-path finishes/Cargo.toml
 	;;
 cache-warm)
-	run cargo build
+	run cargo build --manifest-path finishes/Cargo.toml
 	;;
 daemon:status)
 	run echo daemon status
@@ -43,59 +43,10 @@ daemon:stop)
 	run echo stopping daemon
 	;;
 codex:repair)
-	run cargo fix --allow-dirty
+	run cargo fix --manifest-path finishes/Cargo.toml --allow-dirty
 	;;
 *)
-	echo "Usage: $0 [--confirm] {bootstrap|fast-validate|cache-warm|daemon:{status|start|stop}|codex:repair}"
-
-# default to dry-run
-mode="dry-run"
-if [[ "${1:-}" == "--confirm" ]]; then
-	mode="confirm"
-	shift
-elif [[ "${1:-}" == "--dry-run" ]]; then
-	shift
-fi
-
-if [[ $EUID -eq 0 && $mode == "confirm" ]]; then
-	echo "Refusing to run destructive operations as root without --dry-run" >&2
+	echo "Usage: $0 [--confirm] {bootstrap|fast-validate|cache-warm|daemon:{status|start|stop}|codex:repair}" >&2
 	exit 1
-fi
-
-cmd="${1:-}"
-case "$cmd" in
-bootstrap)
-	echo "[$mode] bootstrap"
-	;;
-fast-validate)
-	echo "[$mode] fast-validate"
-	;;
-cache-warm)
-	echo "[$mode] cache-warm"
-	;;
-daemon:status)
-	echo "[$mode] daemon status"
-	;;
-daemon:start)
-	if [[ $mode == "dry-run" ]]; then
-		echo "[$mode] daemon start"
-	else
-		echo "daemon start"
-	fi
-	;;
-daemon:stop)
-	if [[ $mode == "dry-run" ]]; then
-		echo "[$mode] daemon stop"
-	else
-		echo "daemon stop"
-	fi
-	;;
-codex:repair)
-	echo "[$mode] codex repair"
-	;;
-*)
-	echo "Usage: $0 [--dry-run|--confirm] {bootstrap|fast-validate|cache-warm|daemon:status|daemon:start|daemon:stop|codex:repair}" >&2
-	exit 1
-
 	;;
 esac

--- a/finishes/Cargo.lock
+++ b/finishes/Cargo.lock
@@ -289,7 +289,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "finishes"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "dirs",

--- a/finishes/Cargo.toml
+++ b/finishes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finishes"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [dependencies]

--- a/plan.md
+++ b/plan.md
@@ -1,17 +1,18 @@
 # Plan
 
 ## Goals
-- Add GitHub Actions workflow to build and test the `finishes` crate on `ubuntu-latest` and `macos-latest`.
-- Ensure CI runs `cargo clippy`, `cargo test`, and `cargo dist` packaging.
+- Ensure `codex.sh` commands operate on the `finishes` crate using `cargo --manifest-path finishes/Cargo.toml`.
+- Preserve dry-run defaults and root safety while keeping the script lintable and formatted.
 
 ## Tests
+- `shellcheck codex.sh`
+- `shfmt -d codex.sh`
 - `cargo fmt --all --check`
 - `cargo clippy --manifest-path finishes/Cargo.toml -- -D warnings`
 - `cargo test --manifest-path finishes/Cargo.toml`
-- `cargo dist build --manifest-path finishes/Cargo.toml`
 
 ## SemVer Impact
-- Patch release: workflow update only.
+- Patch release: tooling script adjustment.
 
 ## Rollback Strategy
-- `git revert <commit>` to restore the previous workflow.
+- `git revert <commit>` to restore the previous script.


### PR DESCRIPTION
## Summary
- ensure codex.sh cargo commands target the finishes crate and stay dry-run by default
- bump finishes crate version to 0.5.1 and record change in changelog

## Rationale
- utility script previously ran in repo root; directing commands to the finishes crate makes operations accurate

## SemVer Justification
- patch: internal tooling script update

## Test Evidence
- `shellcheck codex.sh`
- `shfmt -d codex.sh`
- `cargo fmt --manifest-path finishes/Cargo.toml --all --check`
- `cargo clippy --manifest-path finishes/Cargo.toml -- -D warnings`
- `cargo test --manifest-path finishes/Cargo.toml`

## Risk Assessment
- **Low**: affects only helper script; verified with linting and tests

## Affected Packages
- finishes

### Checklist
- [x] Analysis complete
- [x] Docs synced
- [x] CI green
- [ ] Security audit
- [ ] Tags prepared
- [x] codex.sh validated

------
https://chatgpt.com/codex/tasks/task_e_68a1ce65efa48332888f4ae2b8958899